### PR TITLE
Match no-uid from getentryuid with ST findentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SillyTavern - Kofe Script
 This is a simple extension that adds a bunch of random commands needed by me for random reasons.
 ## Features
-- `/getentryuid file= field= value=` Returns the uid of the first entry that matches the value in the selected field. Returns `-1` if no match is found.
+- `/getentryuid file= field= value=` Returns the uid of the first entry that matches the value in the selected field. Returns an empty string if no match is found.
 ## Installation
 Install the extension using this link: ```https://github.com/leandrojofre/SillyTavern-Kofe-Script.git```
 ### Usage

--- a/index.js
+++ b/index.js
@@ -109,12 +109,12 @@ async function getEntryUid(args, value) {
 
     const entries = await getEntriesFromFile(file);
 
-    if (!entries) return "-1";
+    if (!entries) return "";
 
     if (newWorldInfoEntryTemplate[field] === undefined) {
         // @ts-ignore
         if (extensionSettings.show_warnings) toastr.warning(t`Valid field name is required`);
-        return "-1";
+        return "";
     }
 
     const macroedValue = substituteParams(value);
@@ -123,7 +123,7 @@ async function getEntryUid(args, value) {
     if (!target) {
         // @ts-ignore
         if (extensionSettings.show_warnings) toastr.warning(t`No match found`);
-        return "-1";
+        return "";
     }
 
     const uid = target.uid;
@@ -135,7 +135,7 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({
     name: 'getentryuid',
     callback: async (args) => {
         if (!checkStrings([args.file, args.field, args.value], ["File", "Field", "Value"]))
-            return "-1";
+            return "";
 
         return await getEntryUid(args, String(args.value));
     },

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Extension-Template.git",
     "auto_update": true
 }


### PR DESCRIPTION
## Changes
- [Update](https://github.com/leandrojofre/SillyTavern-Kofe-Script/commit/d009c15bc696300f80c762feecbb4fa17e133703) - Match no-uid from `getentryuid` with ST `findentry`